### PR TITLE
audio: add WAV recording and DAC tracing

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -6,6 +6,8 @@
 - Per-connector joystick input mapping: each of the Next's two joystick ports can be driven by an autodetected gamepad or by the host cursor keys + Space (fire); selectable in the new Input menu, in Preferences, via `--joy1-source`/`--joy2-source`, and remembered across sessions
 - The Qt GUI now supports USB gamepads (previously only the SDL-only build did)
 - `--esxdos-stub`: esxDOS `run NAME.nex` now chain-loads a sibling NEX (game selectors / multi-part games run without booting NextZXOS); adds in-memory esxDOS file I/O so games can read/write a config or score file
+- `--wav-record FILE`: record mixed stereo audio directly to a PCM WAV without an audio device or ffmpeg
+- `--dac-trace FILE`: record timestamped physical DAC channel writes to CSV
 
 ### Bug Fixes
 - Tilemap raster-split effects (a scrolling play area with a fixed HUD, split at a line interrupt) now land on the exact scanline, matching real hardware (issue #16)

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -36,6 +36,8 @@
 - 4-channel 8-bit DAC (Soundrive/Specdrum/Covox)
 - Beeper (EAR/MIC)
 - SDL audio output at 44100 Hz stereo
+- Direct 44.1 kHz stereo PCM WAV recording (`--wav-record`), including headless runs and sibling-NEX chaining
+- Timestamped physical DAC write tracing (`--dac-trace` CSV)
 
 ## File format support
 - NEX (v1.0/1.1/1.2): direct page loading, Layer 2 screen/palette from header; saving (V1.2, PC/SP/border/RAM banks — see class doc-comment for honest register limitations)
@@ -59,6 +61,7 @@
 - Emulator speed control (0.5×/1×/2×/4×/custom %, or `--speed`)
 - PNG screenshot (Ctrl+S, toolbar, `--delayed-screenshot`)
 - Video recording to MP4 via FFmpeg pipe (`--record`)
+- Direct audio recording to WAV (`--wav-record`, no FFmpeg required)
 - Preferences dialog (Settings → Preferences…): configure startup defaults (machine type, CPU speed, emulator speed, window scale, CRT filter, start-muted, tape fast-load) and remembered paths (last load dir, default SD image, screenshot dir); saved to `~/.config/JNEXT/jnext.conf` and applied on the next launch — CLI flags always override saved settings
 
 ## Distribution / packaging
@@ -88,7 +91,7 @@
 - `--sdcard` (canonical source for all ROMs — DivMMC, NextZXOS, 48K/128K/+3, Multiface — at TBBlue paths under /MACHINES/NEXT/; optional, falls back to `~/.jnext/sdcard/cspect-next-1gb-fixed.img` — the patched image — offering to download the canonical distribution `cspect-next-1gb.img` and produce that patched copy, with a GUI download progress bar)
 - `--sdcard-download-confirm`, `--sdcard-download-force` (auto-provision / force re-download of the fallback image)
 - `--inject` raw binary with `--inject-org`, `--inject-pc`, `--inject-delay`
-- `--rewind-buffer-size`, `--speed`, `--record`, `--rzx-play`, `--rzx-record`
+- `--rewind-buffer-size`, `--speed`, `--record`, `--wav-record`, `--dac-trace`, `--rzx-play`, `--rzx-record`
 - `--magic-breakpoint`, `--magic-port`, `--magic-port-mode`
 - `--delayed-screenshot-layers ula,layer2,sprites,tiles,all` — compose only the named layers into the screenshot (default all), for capturing each graphics layer in isolation
 - `--log-level` per subsystem (cpu, video, audio, etc.)

--- a/USAGE.md
+++ b/USAGE.md
@@ -163,6 +163,8 @@ with `-` is treated as an option, never as a filename.
 | Option | Description |
 |--------|-------------|
 | `--record FILE` | Record video + audio to an MP4 (requires `ffmpeg` on the PATH) |
+| `--wav-record FILE` | Record the mixed stereo output to a 44.1 kHz, 16-bit PCM WAV; works headless and requires neither an audio device nor `ffmpeg` |
+| `--dac-trace FILE` | Record `segment,tstate,channel,value` rows for physical DAC writes; a cold boot starts a new segment |
 | `--rzx-play FILE` | Play back an RZX recording |
 | `--rzx-record FILE` | Record input to an RZX file |
 | `--rewind-buffer-size N` | Frame-snapshot ring buffer for backwards execution (opt-in; default 0 = off) |
@@ -172,7 +174,7 @@ with `-` is treated as an option, never as a filename.
 
 | Option | Description |
 |--------|-------------|
-| `--headless` | Run with no display and no audio, at maximum speed |
+| `--headless` | Run with no display or audio device, at maximum speed |
 | `--benchmark N` | Headless-only: run exactly N frames uncapped, print one machine-parseable `BENCH` line (wall s, fps, T-states/s, T-states/frame, CPU speed, host core, build type) plus a human summary to stdout, then exit. Used by `make bench` (`test/bench/bench.sh`) |
 | `--benchmark-label NAME` | Workload label printed verbatim in the `BENCH` line (default: loaded file's basename, or `boot-<machine>`). No whitespace |
 | `--delayed-screenshot FILE` | Save a PNG screenshot after a delay |
@@ -244,6 +246,13 @@ Notes worth knowing:
 
 - **Video recording** (`--record FILE`, or **File > Record MPEG4 Video**) pipes
   video and audio to `ffmpeg`, which must be installed.
+- **WAV recording** (`--wav-record FILE`) captures the mixed audio before the
+  host playback device. It works in headless mode and continues through cold
+  boots such as sibling-NEX chaining. It cannot be combined with `--silent`,
+  which disables mixer synthesis. If the emulator exits abnormally, the file
+  may retain its initial zero-length data header even though PCM follows it.
+- **DAC tracing** (`--dac-trace FILE`) records guest DAC writes before mixing.
+  Channels are numbered 0–3 (A–D), and timestamps are CPU T-states.
 
 ## Logging
 

--- a/src/audio/audio_recorder.cpp
+++ b/src/audio/audio_recorder.cpp
@@ -1,0 +1,140 @@
+#include "audio/audio_recorder.h"
+
+#include <algorithm>
+#include <array>
+#include <cerrno>
+#include <cstring>
+#include <limits>
+
+namespace {
+
+void put_u16_le(uint8_t* out, uint16_t value)
+{
+    out[0] = static_cast<uint8_t>(value);
+    out[1] = static_cast<uint8_t>(value >> 8);
+}
+
+void put_u32_le(uint8_t* out, uint32_t value)
+{
+    out[0] = static_cast<uint8_t>(value);
+    out[1] = static_cast<uint8_t>(value >> 8);
+    out[2] = static_cast<uint8_t>(value >> 16);
+    out[3] = static_cast<uint8_t>(value >> 24);
+}
+
+}  // namespace
+
+AudioRecorder::~AudioRecorder()
+{
+    stop();
+}
+
+bool AudioRecorder::start(const std::string& path, uint32_t sample_rate)
+{
+    if (is_recording()) {
+        last_error_ = "an audio capture is already active";
+        return false;
+    }
+    if (sample_rate == 0 || sample_rate > std::numeric_limits<uint32_t>::max() / 4u) {
+        set_error("sample rate is outside the WAV PCM range");
+        return false;
+    }
+
+    last_error_.clear();
+    failed_ = false;
+    data_bytes_ = 0;
+    sample_rate_ = sample_rate;
+    file_ = std::fopen(path.c_str(), "wb+");
+    if (!file_) {
+        set_error("cannot open '" + path + "': " + std::strerror(errno));
+        return false;
+    }
+
+    if (!write_header(0)) {
+        std::fclose(file_);
+        file_ = nullptr;
+        return false;
+    }
+    return true;
+}
+
+void AudioRecorder::capture(const int16_t* samples, int stereo_pair_count)
+{
+    if (!file_ || failed_ || !samples || stereo_pair_count <= 0) return;
+
+    constexpr size_t PAIRS_PER_CHUNK = 1024;
+    std::array<uint8_t, PAIRS_PER_CHUNK * 4> bytes{};
+
+    int offset = 0;
+    while (offset < stereo_pair_count) {
+        const size_t pairs = std::min(
+            static_cast<size_t>(stereo_pair_count - offset), PAIRS_PER_CHUNK);
+        for (size_t i = 0; i < pairs; ++i) {
+            put_u16_le(&bytes[i * 4],
+                       static_cast<uint16_t>(samples[(offset + static_cast<int>(i)) * 2]));
+            put_u16_le(&bytes[i * 4 + 2],
+                       static_cast<uint16_t>(samples[(offset + static_cast<int>(i)) * 2 + 1]));
+        }
+
+        const size_t byte_count = pairs * 4;
+        if (std::fwrite(bytes.data(), 1, byte_count, file_) != byte_count) {
+            set_error("failed while writing PCM data");
+            return;
+        }
+        data_bytes_ += byte_count;
+        offset += static_cast<int>(pairs);
+    }
+}
+
+bool AudioRecorder::stop()
+{
+    if (!file_) return !failed_;
+
+    if (data_bytes_ > std::numeric_limits<uint32_t>::max() - 36u) {
+        set_error("capture is too large for a standard WAV file");
+    } else if (std::fflush(file_) != 0) {
+        set_error("failed to flush PCM data");
+    } else if (std::fseek(file_, 0, SEEK_SET) != 0) {
+        set_error("failed to seek while finalizing WAV header");
+    } else if (!write_header(static_cast<uint32_t>(data_bytes_))) {
+        // write_header records the error.
+    } else if (std::fflush(file_) != 0) {
+        set_error("failed to flush WAV header");
+    }
+
+    if (std::fclose(file_) != 0 && !failed_) {
+        set_error("failed to close WAV file");
+    }
+    file_ = nullptr;
+    return !failed_;
+}
+
+bool AudioRecorder::write_header(uint32_t data_bytes)
+{
+    std::array<uint8_t, 44> header{};
+    std::memcpy(&header[0], "RIFF", 4);
+    put_u32_le(&header[4], 36u + data_bytes);
+    std::memcpy(&header[8], "WAVE", 4);
+    std::memcpy(&header[12], "fmt ", 4);
+    put_u32_le(&header[16], 16);
+    put_u16_le(&header[20], 1);  // PCM
+    put_u16_le(&header[22], 2);  // stereo
+    put_u32_le(&header[24], sample_rate_);
+    put_u32_le(&header[28], sample_rate_ * 4u);
+    put_u16_le(&header[32], 4);   // stereo frame size
+    put_u16_le(&header[34], 16);  // bits per sample
+    std::memcpy(&header[36], "data", 4);
+    put_u32_le(&header[40], data_bytes);
+
+    if (std::fwrite(header.data(), 1, header.size(), file_) != header.size()) {
+        set_error("failed to write WAV header");
+        return false;
+    }
+    return true;
+}
+
+void AudioRecorder::set_error(const std::string& message)
+{
+    failed_ = true;
+    if (last_error_.empty()) last_error_ = message;
+}

--- a/src/audio/audio_recorder.h
+++ b/src/audio/audio_recorder.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <cstdint>
+#include <cstdio>
+#include <string>
+
+/// Writes the mixer's stereo 16-bit PCM output to a WAV file.
+///
+/// The frontend owns the recorder so captures remain open across emulator
+/// cold boots, including sibling-NEX chaining.
+class AudioRecorder {
+public:
+    AudioRecorder() = default;
+    ~AudioRecorder();
+
+    AudioRecorder(const AudioRecorder&) = delete;
+    AudioRecorder& operator=(const AudioRecorder&) = delete;
+
+    bool start(const std::string& path, uint32_t sample_rate = 44100);
+    void capture(const int16_t* samples, int stereo_pair_count);
+    bool stop();
+
+    bool is_recording() const { return file_ != nullptr; }
+    const std::string& last_error() const { return last_error_; }
+
+private:
+    bool write_header(uint32_t data_bytes);
+    void set_error(const std::string& message);
+
+    std::FILE* file_ = nullptr;
+    uint32_t sample_rate_ = 44100;
+    uint64_t data_bytes_ = 0;
+    bool failed_ = false;
+    std::string last_error_;
+};

--- a/src/audio/dac.cpp
+++ b/src/audio/dac.cpp
@@ -14,7 +14,25 @@ void Dac::reset()
 
 void Dac::write_channel(int ch, uint8_t val)
 {
-    if (ch >= 0 && ch < 4) ch_[ch] = val;
+    if (ch < 0 || ch >= 4) return;
+    ch_[ch] = val;
+    if (write_callback_) write_callback_(ch, val);
+}
+
+void Dac::write_mono(uint8_t val)
+{
+    write_channel(0, val);
+    write_channel(3, val);
+}
+
+void Dac::write_left(uint8_t val)
+{
+    write_channel(1, val);
+}
+
+void Dac::write_right(uint8_t val)
+{
+    write_channel(2, val);
 }
 
 void Dac::save_state(StateWriter& w) const

--- a/src/audio/dac.h
+++ b/src/audio/dac.h
@@ -1,6 +1,8 @@
 #pragma once
 
 #include <cstdint>
+#include <functional>
+#include <utility>
 
 /// Soundrive 4-channel 8-bit DAC emulation.
 ///
@@ -24,9 +26,12 @@ public:
     void write_channel(int ch, uint8_t val);
 
     /// NextREG mirror writes (from VHDL: nr_mono writes A+D, nr_left writes B, nr_right writes C).
-    void write_mono(uint8_t val)  { ch_[0] = val; ch_[3] = val; }
-    void write_left(uint8_t val)  { ch_[1] = val; }
-    void write_right(uint8_t val) { ch_[2] = val; }
+    void write_mono(uint8_t val);
+    void write_left(uint8_t val);
+    void write_right(uint8_t val);
+
+    using WriteCallback = std::function<void(int, uint8_t)>;
+    void set_write_callback(WriteCallback callback) { write_callback_ = std::move(callback); }
 
     /// Get 9-bit stereo output (A+B for left, C+D for right).
     uint16_t pcm_left() const  { return static_cast<uint16_t>(ch_[0]) + ch_[1]; }
@@ -37,4 +42,5 @@ public:
 
 private:
     uint8_t ch_[4];  // A, B, C, D
+    WriteCallback write_callback_;
 };

--- a/src/audio/dac_trace_recorder.cpp
+++ b/src/audio/dac_trace_recorder.cpp
@@ -1,0 +1,64 @@
+#include "audio/dac_trace_recorder.h"
+
+#include <cerrno>
+#include <cstring>
+
+DacTraceRecorder::~DacTraceRecorder()
+{
+    stop();
+}
+
+bool DacTraceRecorder::start(const std::string& path)
+{
+    if (is_recording()) {
+        last_error_ = "a DAC trace is already active";
+        return false;
+    }
+
+    last_error_.clear();
+    failed_ = false;
+    have_tstate_ = false;
+    segment_ = 0;
+    file_ = std::fopen(path.c_str(), "w");
+    if (!file_) {
+        set_error("cannot open '" + path + "': " + std::strerror(errno));
+        return false;
+    }
+    if (std::fputs("segment,tstate,channel,value\n", file_) < 0) {
+        set_error("failed to write DAC trace header");
+        std::fclose(file_);
+        file_ = nullptr;
+        return false;
+    }
+    return true;
+}
+
+void DacTraceRecorder::capture(uint64_t tstate, int channel, uint8_t value)
+{
+    if (!file_ || failed_) return;
+    if (have_tstate_ && tstate < last_tstate_) ++segment_;
+    last_tstate_ = tstate;
+    have_tstate_ = true;
+
+    if (std::fprintf(file_, "%u,%llu,%d,%u\n", segment_,
+                     static_cast<unsigned long long>(tstate), channel,
+                     static_cast<unsigned>(value)) < 0) {
+        set_error("failed while writing DAC trace");
+    }
+}
+
+bool DacTraceRecorder::stop()
+{
+    if (!file_) return !failed_;
+    if (std::fclose(file_) != 0 && !failed_) {
+        set_error("failed to close DAC trace");
+    }
+    file_ = nullptr;
+    return !failed_;
+}
+
+void DacTraceRecorder::set_error(const std::string& message)
+{
+    failed_ = true;
+    if (last_error_.empty()) last_error_ = message;
+}

--- a/src/audio/dac_trace_recorder.h
+++ b/src/audio/dac_trace_recorder.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <cstdint>
+#include <cstdio>
+#include <string>
+
+/// Writes guest DAC activity to CSV. A cold boot starts a new segment when
+/// the emulated T-state clock returns to zero.
+class DacTraceRecorder {
+public:
+    DacTraceRecorder() = default;
+    ~DacTraceRecorder();
+
+    DacTraceRecorder(const DacTraceRecorder&) = delete;
+    DacTraceRecorder& operator=(const DacTraceRecorder&) = delete;
+
+    bool start(const std::string& path);
+    void capture(uint64_t tstate, int channel, uint8_t value);
+    bool stop();
+
+    bool is_recording() const { return file_ != nullptr; }
+    const std::string& last_error() const { return last_error_; }
+
+private:
+    void set_error(const std::string& message);
+
+    std::FILE* file_ = nullptr;
+    uint64_t last_tstate_ = 0;
+    unsigned segment_ = 0;
+    bool have_tstate_ = false;
+    bool failed_ = false;
+    std::string last_error_;
+};

--- a/src/audio/mixer.cpp
+++ b/src/audio/mixer.cpp
@@ -156,10 +156,11 @@ void Mixer::emit_sample()
     write_pos_ = (write_pos_ + 2) % (RING_BUFFER_SIZE * 2);
     count_++;
 
-    // Notify the recording callback (if any) with this sample pair.
-    if (record_callback_) {
+    // WAV and video recording are independent consumers.
+    if (record_callback_ || capture_callback_) {
         int16_t pair[2] = { static_cast<int16_t>(sL), static_cast<int16_t>(sR) };
-        record_callback_(pair, 1);
+        if (record_callback_) record_callback_(pair, 1);
+        if (capture_callback_) capture_callback_(pair, 1);
     }
 }
 

--- a/src/audio/mixer.h
+++ b/src/audio/mixer.h
@@ -84,6 +84,10 @@ public:
     using RecordCallback = std::function<void(const int16_t*, int)>;
     void set_record_callback(RecordCallback cb) { record_callback_ = std::move(cb); }
 
+    /// Independent mixed-audio capture, usable alongside video recording.
+    using CaptureCallback = std::function<void(const int16_t*, int)>;
+    void set_capture_callback(CaptureCallback cb) { capture_callback_ = std::move(cb); }
+
     /// Wire the I2s source (not owned). When set, generate_sample() adds
     /// the latched 10-bit L/R pair (zero-extended) into the 13-bit sum,
     /// mirroring audio_mixer.vhd:89-90,99-100.
@@ -123,6 +127,7 @@ private:
     int count_ = 0;
 
     RecordCallback record_callback_;
+    CaptureCallback capture_callback_;
 
     I2s* i2s_{nullptr};  // Not owned; Emulator owns the I2s instance.
 

--- a/src/core/emulator.cpp
+++ b/src/core/emulator.cpp
@@ -166,8 +166,17 @@ bool Emulator::init(const EmulatorConfig& cfg, bool preserve_memory)
     beeper_.reset();
     turbosound_.reset();
     dac_.reset();
+    if (cfg.dac_write_callback) {
+        dac_.set_write_callback([this, callback = cfg.dac_write_callback]
+                                (int channel, uint8_t value) {
+            callback(monotonic_tstates(), channel, value);
+        });
+    } else {
+        dac_.set_write_callback({});
+    }
     i2s_.reset();
     mixer_.reset();
+    mixer_.set_capture_callback(cfg.audio_capture_callback);
     ctc_.reset();
     dma_.reset();
     spi_.reset();

--- a/src/core/emulator_config.h
+++ b/src/core/emulator_config.h
@@ -3,6 +3,7 @@
 #include <cstdint>
 #include <cstdio>
 #include <ctime>
+#include <functional>
 #include <string>
 
 // MachineType is the canonical shared enum; defined once in contention.h.
@@ -201,6 +202,10 @@ struct EmulatorConfig {
     // EAR *input* bit (read by the CPU on port 0xFE) is computed
     // independently of the mixer and is unaffected.
     bool silent = false;
+
+    // Host capture callbacks are reattached by init() after a cold boot.
+    std::function<void(const int16_t*, int)> audio_capture_callback;
+    std::function<void(uint64_t, int, uint8_t)> dac_write_callback;
 };
 
 // ---------------------------------------------------------------------------

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -746,8 +746,11 @@ int main(int argc, char* argv[]) {
         app.shutdown();
         // shutdown() decides the status: a --delayed-screenshot that was
         // requested and never written exits non-zero, so a CI script cannot
-        // mistake a missing PNG for success.
-        return capture_ok ? app.exit_code() : 1;
+        // mistake a missing PNG for success. A capture-finalize failure makes
+        // an otherwise-clean run exit 1, but never replaces the app's own
+        // non-zero code with a less specific one.
+        if (app.exit_code() != 0) return app.exit_code();
+        return capture_ok ? 0 : 1;
     };
 
     int result;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,3 +1,5 @@
+#include "audio/audio_recorder.h"
+#include "audio/dac_trace_recorder.h"
 #include "core/log.h"
 #include "core/sdcard_provisioner.h"
 #include "core/video_recorder.h"
@@ -97,6 +99,9 @@ static void print_usage(const char* prog) {
         "  --magic-port PORT        Enable magic debug port at PORT (hex, e.g. 0x00FF)\n"
         "  --magic-port-mode MODE   Magic port output mode: hex, dec, ascii, line (default: hex)\n"
         "  --record FILE            Record video/audio to FILE (MP4, requires ffmpeg)\n"
+        "  --wav-record FILE        Record mixed stereo audio to a 44.1 kHz PCM WAV;\n"
+        "                           works headless and does not require ffmpeg\n"
+        "  --dac-trace FILE         Record timestamped physical DAC writes to CSV\n"
         "  --rzx-play FILE         Play back an RZX recording file\n"
         "  --rzx-record FILE       Record input to an RZX file\n"
         "  --speed PERCENT         Emulator speed as %% (50=half, 100=normal, 200=2x, 400=4x)\n"
@@ -189,6 +194,8 @@ int main(int argc, char* argv[]) {
     uint16_t    magic_port_address = 0;
     EmulatorConfig::MagicPortMode magic_port_mode = EmulatorConfig::MagicPortMode::HEX;
     std::string record_file;
+    std::string wav_record_file;
+    std::string dac_trace_file;
     std::string rzx_play_file;
     std::string rzx_record_file;
     int         speed_percent = 100;
@@ -304,6 +311,10 @@ int main(int argc, char* argv[]) {
             else { fprintf(stderr, "Unknown magic port mode: %s (valid: hex, dec, ascii, line)\n", argv[i]); return 1; }
         } else if (arg == "--record" && i + 1 < argc) {
             record_file = argv[++i];
+        } else if (arg == "--wav-record" && i + 1 < argc) {
+            wav_record_file = argv[++i];
+        } else if (arg == "--dac-trace" && i + 1 < argc) {
+            dac_trace_file = argv[++i];
         } else if (arg == "--rzx-play" && i + 1 < argc) {
             rzx_play_file = argv[++i];
         } else if (arg == "--rzx-record" && i + 1 < argc) {
@@ -415,6 +426,11 @@ int main(int argc, char* argv[]) {
         fprintf(stderr, "--benchmark-label requires --benchmark N.\n");
         return 1;
     }
+    if (silent && !wav_record_file.empty()) {
+        fprintf(stderr,
+                "--wav-record cannot be combined with --silent because --silent disables mixer synthesis.\n");
+        return 1;
+    }
 
     // Task 66 (Configurability) — load saved GUI preferences once, early
     // enough to seed the SD-card resolution below. Only ever done for the
@@ -509,6 +525,8 @@ int main(int argc, char* argv[]) {
             "(the host cursor keys can drive only one connector).\n");
         return 1;
     }
+    AudioRecorder audio_recorder;
+    DacTraceRecorder dac_trace_recorder;
 
     // Helper lambda: configure and run any app object with the common interface.
     auto configure_and_run = [&](auto& app) -> int {
@@ -567,9 +585,41 @@ int main(int argc, char* argv[]) {
             }
         }
 #endif
+        if (cfg.silent && !wav_record_file.empty()) {
+            fprintf(stderr,
+                    "--wav-record cannot be used while audio is disabled in preferences.\n");
+            return 1;
+        }
+        if (!wav_record_file.empty()) {
+            if (!audio_recorder.start(wav_record_file)) {
+                Log::audio()->error("Failed to start WAV recording: {}",
+                                    audio_recorder.last_error());
+                return 1;
+            }
+            cfg.audio_capture_callback = [&audio_recorder](const int16_t* samples,
+                                                           int count) {
+                audio_recorder.capture(samples, count);
+            };
+        }
+        if (!dac_trace_file.empty()) {
+            if (!dac_trace_recorder.start(dac_trace_file)) {
+                Log::audio()->error("Failed to start DAC trace: {}",
+                                    dac_trace_recorder.last_error());
+                audio_recorder.stop();
+                return 1;
+            }
+            cfg.dac_write_callback = [&dac_trace_recorder]
+                                     (uint64_t tstate, int channel, uint8_t value) {
+                dac_trace_recorder.capture(tstate, channel, value);
+            };
+        }
         app.set_config(cfg);
 
-        if (!app.init(argc, argv)) return 1;
+        if (!app.init(argc, argv)) {
+            audio_recorder.stop();
+            dac_trace_recorder.stop();
+            return 1;
+        }
 
         // Task 66 — apply the saved GUI preferences that have no CLI
         // competitor (CPU speed, window scale, CRT filter, tape fast-load)
@@ -643,6 +693,8 @@ int main(int argc, char* argv[]) {
                 app.set_tape_realtime(true);
             } else {
                 Log::emulator()->error("--load: unsupported file extension '{}' (supported: .nex, .sna, .szx, .z80, .tap, .tzx, .wav, .rzx)", ext);
+                audio_recorder.stop();
+                dac_trace_recorder.stop();
                 return 1;
             }
         }
@@ -672,11 +724,30 @@ int main(int argc, char* argv[]) {
             app.emulator().stop_recording();
         }
 
+        bool capture_ok = true;
+        if (audio_recorder.is_recording()) {
+            app.emulator().mixer().set_capture_callback({});
+            capture_ok = audio_recorder.stop();
+            if (!capture_ok) {
+                Log::audio()->error("Failed to finalize WAV recording: {}",
+                                    audio_recorder.last_error());
+            }
+        }
+        if (dac_trace_recorder.is_recording()) {
+            app.emulator().dac().set_write_callback({});
+            const bool trace_ok = dac_trace_recorder.stop();
+            capture_ok = capture_ok && trace_ok;
+            if (!trace_ok) {
+                Log::audio()->error("Failed to finalize DAC trace: {}",
+                                    dac_trace_recorder.last_error());
+            }
+        }
+
         app.shutdown();
         // shutdown() decides the status: a --delayed-screenshot that was
         // requested and never written exits non-zero, so a CI script cannot
         // mistake a missing PNG for success.
-        return app.exit_code();
+        return capture_ok ? app.exit_code() : 1;
     };
 
     int result;

--- a/test/00regression/functional_tests.conf
+++ b/test/00regression/functional_tests.conf
@@ -14,7 +14,7 @@
 # The screenshot tests have their own manifest: regression_tests.conf.
 # The assertion lint is always row 1 and is not listed here.
 
-# expect: 30
+# expect: 32
 #   The number of functional tests declared below, pinned. regression.sh FAILS if the
 #   count here and the rows below ever disagree. Without it, deleting a test
 #   from this file just shrinks both sides of the completeness check together
@@ -27,6 +27,8 @@ harness-selftest-func
 magic-bp-func
 magic-port-func
 video-record-func
+wav-record-func
+dac-trace-func
 render-skip-turbo-func
 sprite-collision-turbo-func
 audio-underrun-func

--- a/test/00regression/regression.sh
+++ b/test/00regression/regression.sh
@@ -491,6 +491,91 @@ if want video-record-func; then
     fi
 fi
 
+# Direct WAV capture must use the mixed-audio path in headless mode and remain
+# attached when sibling-NEX chaining reconstructs the Emulator. The selector
+# chains at frame 100; a recording substantially longer than that first leg
+# proves capture resumed after the cold boot.
+if want wav-record-func; then
+    begin_func wav-record-func
+    wav_file="$TMP_DIR/direct_audio.wav"
+    menu_nex="$PROJECT_DIR/test/00regression/nex/menu.nex"
+    if reject_out=$("$JNEXT" --headless --silent --wav-record "$wav_file" 2>&1); then
+        reject_status=0
+    else
+        reject_status=$?
+    fi
+    out=$(timeout --foreground --kill-after=5s 30s "$JNEXT" --headless --machine next \
+        "${SD_CARD_ARGS[@]}" --esxdos-stub --load "$menu_nex" \
+        --wav-record "$wav_file" --delayed-keypress-frames 100 1 \
+        --delayed-automatic-exit-frames 220 2>&1) || true
+    chained=$(echo "$out" | grep -cE "NEX: loaded '.*red\.nex'" || true)
+    if [[ "$reject_status" -eq 0 ]] ||
+       ! echo "$reject_out" | grep -q -- "--wav-record cannot be combined with --silent"; then
+        echo -e "${RED}FAIL${RESET} (--silent conflict was not rejected clearly)"
+        fail=$((fail + 1))
+    elif [[ "$chained" -lt 1 ]]; then
+        echo -e "${RED}FAIL${RESET} (selector did not chain-load red.nex)"
+        fail=$((fail + 1))
+    elif ! command -v python3 &>/dev/null; then
+        echo -e "${YELLOW}SKIP${RESET} (python3 not available for WAV validation)"
+        skip=$((skip + 1))
+    elif wav_out=$(python3 - "$wav_file" <<'PY'
+import struct
+import sys
+
+path = sys.argv[1]
+with open(path, "rb") as wav:
+    data = wav.read()
+if len(data) < 44:
+    raise SystemExit("WAV is shorter than its header")
+if data[:4] != b"RIFF" or data[8:12] != b"WAVE" or data[36:40] != b"data":
+    raise SystemExit("invalid WAV container")
+rate, channels, bits, payload = (
+    struct.unpack_from("<I", data, 24)[0],
+    struct.unpack_from("<H", data, 22)[0],
+    struct.unpack_from("<H", data, 34)[0],
+    struct.unpack_from("<I", data, 40)[0],
+)
+if (rate, channels, bits) != (44100, 2, 16):
+    raise SystemExit(f"unexpected format {rate} Hz/{channels} ch/{bits} bit")
+if payload != len(data) - 44 or payload < 600000:
+    raise SystemExit(f"capture stopped early ({payload} payload bytes)")
+print(f"{payload} payload bytes across selector cold boot")
+PY
+    ); then
+        echo -e "${GREEN}PASS${RESET} ($wav_out)"
+        pass=$((pass + 1))
+    else
+        echo -e "${RED}FAIL${RESET} ($wav_out)"
+        fail=$((fail + 1))
+    fi
+fi
+
+# Exercise --dac-trace through the real port-dispatch path. The injected Z80N
+# program runs DI; NEXTREG $08,$08; writes $11/$22/$33/$44
+# to Soundrive A/B/C/D, then idles.
+if want dac-trace-func; then
+    begin_func dac-trace-func
+    dac_bin="$TMP_DIR/dac_trace.bin"
+    dac_csv="$TMP_DIR/dac_trace.csv"
+    printf '\xF3\xED\x91\x08\x08\x3E\x11\xD3\x1F\x3E\x22\xD3\x0F\x3E\x33\xD3\x4F\x3E\x44\xD3\x5F\x18\xFE' > "$dac_bin"
+    if timeout --foreground --kill-after=5s 20s "$JNEXT" --headless --machine next \
+        "${SD_CARD_ARGS[@]}" --inject "$dac_bin" --inject-org 8000 \
+        --inject-pc 8000 --dac-trace "$dac_csv" \
+        --delayed-automatic-exit-frames 30 &>/dev/null &&
+       [[ $(head -n 1 "$dac_csv" 2>/dev/null) == "segment,tstate,channel,value" ]] &&
+       grep -qE '^[0-9]+,[0-9]+,0,17$' "$dac_csv" &&
+       grep -qE '^[0-9]+,[0-9]+,1,34$' "$dac_csv" &&
+       grep -qE '^[0-9]+,[0-9]+,2,51$' "$dac_csv" &&
+       grep -qE '^[0-9]+,[0-9]+,3,68$' "$dac_csv"; then
+        echo -e "${GREEN}PASS${RESET} (physical DAC channels A-D traced through CLI)"
+        pass=$((pass + 1))
+    else
+        echo -e "${RED}FAIL${RESET} (missing or incorrect DAC CSV rows)"
+        fail=$((fail + 1))
+    fi
+fi
+
 # Task 27 C6 — render-skip at turbo speed (Qt frontend only). At --speed 400
 # the Qt tick throttles Emulator::render_frame() to ~50 Hz wall-clock for
 # frames nobody displays. This row proves the three load-bearing guarantees:

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -367,6 +367,14 @@ target_link_libraries(audio_test PRIVATE jnext_audio)
 target_include_directories(audio_test PRIVATE ${CMAKE_SOURCE_DIR}/src)
 add_test(NAME audio_tests COMMAND audio_test)
 
+add_executable(audio_capture_test audio/audio_capture_test.cpp)
+target_link_libraries(audio_capture_test PRIVATE
+    jnext_core jnext_cpu jnext_memory jnext_video
+    jnext_audio jnext_port jnext_peripheral jnext_input
+    jnext_save jnext_debug spdlog::spdlog zot_tzx ZLIB::ZLIB)
+target_include_directories(audio_capture_test PRIVATE ${CMAKE_SOURCE_DIR}/src)
+add_test(NAME audio_capture_tests COMMAND audio_capture_test)
+
 # Log change-gate test (Task 24). Drives a real Emulator through the port path
 # and counts the log lines NR 0x07 actually emits. Own binary: the natural home
 # (nextreg_integration_test) has a local fmt() that collides with spdlog's fmt.

--- a/test/SUBSYSTEM-TESTS-STATUS.md
+++ b/test/SUBSYSTEM-TESTS-STATUS.md
@@ -45,6 +45,7 @@ VHDL-derived compliance test suite for the JNEXT ZX Spectrum Next emulator. All 
 | Audio (NextREG)       |       33 |       33 |      0 |       0 |    100% | 🟢 All tests pass. |
 | Audio (port dispatch) |       23 |       23 |      0 |       0 |    100% | 🟢 All tests pass. |
 | Audio (pacing)        |       22 |       22 |      0 |       0 |    100% | 🟢 All tests pass. |
+| Audio (capture)       |       17 |       17 |      0 |       0 |    100% | 🟢 All tests pass. |
 | Present cadence       |       34 |       34 |      0 |       0 |    100% | 🟢 All tests pass. |
 | Tick-delivery stats   |       32 |       32 |      0 |       0 |    100% | 🟢 All tests pass. |
 | Logging               |       10 |       10 |      0 |       0 |    100% | 🟢 All tests pass. |
@@ -61,6 +62,6 @@ VHDL-derived compliance test suite for the JNEXT ZX Spectrum Next emulator. All 
 | Debugger Video Panel  |       83 |       83 |      0 |       0 |    100% | 🟢 All tests pass. |
 | Debugger Audio Panel  |       15 |       15 |      0 |       0 |    100% | 🟢 All tests pass. |
 | Debugger Quit Gate    |        5 |        5 |      0 |       0 |    100% | 🟢 All tests pass. |
-| **Total**             | **4980** | **4980** |  **0** |   **0** | **100%**| 🟢 All tests pass. |
+| **Total**             | **4997** | **4997** |  **0** |   **0** | **100%**| 🟢 All tests pass. |
 
 **SKIP:** Functionality that has been traced from VHDL to a test case, but still has not been developed/fixed in C++ code.

--- a/test/audio/audio_capture_test.cpp
+++ b/test/audio/audio_capture_test.cpp
@@ -1,0 +1,221 @@
+#include "audio/audio_recorder.h"
+#include "audio/dac_trace_recorder.h"
+#include "core/emulator.h"
+#include "core/emulator_config.h"
+#include "platform/emulator_boot.h"
+
+#include <chrono>
+#include <cstdint>
+#include <cstdio>
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace {
+
+int passed = 0;
+int failed = 0;
+
+void check(const char* name, bool condition)
+{
+    if (condition) {
+        ++passed;
+    } else {
+        ++failed;
+        std::printf("FAIL: %s\n", name);
+    }
+}
+
+std::filesystem::path temp_file(const char* label, const char* extension)
+{
+    const auto stamp = std::chrono::high_resolution_clock::now()
+                           .time_since_epoch().count();
+    return std::filesystem::temp_directory_path() /
+           (std::string("jnext-") + label + "-" + std::to_string(stamp) + extension);
+}
+
+std::vector<uint8_t> read_binary(const std::filesystem::path& path)
+{
+    std::ifstream input(path, std::ios::binary);
+    return {std::istreambuf_iterator<char>(input), std::istreambuf_iterator<char>()};
+}
+
+std::string read_text(const std::filesystem::path& path)
+{
+    std::ifstream input(path);
+    return {std::istreambuf_iterator<char>(input), std::istreambuf_iterator<char>()};
+}
+
+uint16_t u16_le(const std::vector<uint8_t>& bytes, size_t offset)
+{
+    return static_cast<uint16_t>(bytes[offset]) |
+           (static_cast<uint16_t>(bytes[offset + 1]) << 8);
+}
+
+uint32_t u32_le(const std::vector<uint8_t>& bytes, size_t offset)
+{
+    return static_cast<uint32_t>(bytes[offset]) |
+           (static_cast<uint32_t>(bytes[offset + 1]) << 8) |
+           (static_cast<uint32_t>(bytes[offset + 2]) << 16) |
+           (static_cast<uint32_t>(bytes[offset + 3]) << 24);
+}
+
+void wav_format_test()
+{
+    const auto path = temp_file("audio-format", ".wav");
+    AudioRecorder recorder;
+    const int16_t samples[] = {
+        static_cast<int16_t>(0x1234), static_cast<int16_t>(-2),
+        static_cast<int16_t>(-32768), static_cast<int16_t>(32767),
+        0, 1,
+    };
+
+    check("WAV rejects a zero sample rate", !recorder.start(path.string(), 0));
+    check("WAV starts and rejects a second start",
+          recorder.start(path.string()) && !recorder.start(path.string()));
+    recorder.capture(samples, 3);
+    check("WAV finalizes", recorder.stop());
+
+    const auto bytes = read_binary(path);
+    check("WAV file size", bytes.size() == 56);
+    const bool complete = bytes.size() >= 56;
+    check("WAV container IDs", complete &&
+          std::string(bytes.begin(), bytes.begin() + 4) == "RIFF" &&
+          std::string(bytes.begin() + 8, bytes.begin() + 12) == "WAVE" &&
+          std::string(bytes.begin() + 12, bytes.begin() + 16) == "fmt " &&
+          std::string(bytes.begin() + 36, bytes.begin() + 40) == "data");
+    check("WAV PCM header", complete &&
+          u32_le(bytes, 4) == 48 && u32_le(bytes, 16) == 16 &&
+          u16_le(bytes, 20) == 1 && u16_le(bytes, 22) == 2 &&
+          u32_le(bytes, 24) == 44100 && u32_le(bytes, 28) == 176400 &&
+          u16_le(bytes, 32) == 4 && u16_le(bytes, 34) == 16 &&
+          u32_le(bytes, 40) == 12);
+    const std::vector<uint8_t> expected = {
+        0x34, 0x12, 0xFE, 0xFF,
+        0x00, 0x80, 0xFF, 0x7F,
+        0x00, 0x00, 0x01, 0x00,
+    };
+    check("WAV little-endian PCM", complete &&
+          std::vector<uint8_t>(bytes.begin() + 44, bytes.end()) == expected);
+    std::filesystem::remove(path);
+}
+
+void dac_callback_mapping_test()
+{
+    Dac dac;
+    std::vector<std::pair<int, uint8_t>> writes;
+    dac.set_write_callback([&writes](int channel, uint8_t value) {
+        writes.emplace_back(channel, value);
+    });
+
+    dac.write_mono(10);
+    dac.write_left(20);
+    dac.write_right(30);
+    dac.write_channel(-1, 40);
+    dac.write_channel(4, 50);
+
+    const std::vector<std::pair<int, uint8_t>> expected = {
+        {0, 10}, {3, 10}, {1, 20}, {2, 30},
+    };
+    check("DAC callback reports physical mirror channels", writes == expected);
+}
+
+void mixer_callback_fanout_test()
+{
+    Beeper beeper;
+    TurboSound turbosound;
+    Dac dac;
+    Mixer mixer;
+    int video_samples = 0;
+    int wav_samples = 0;
+    int16_t video_pair[2]{};
+    int16_t wav_pair[2]{};
+    mixer.set_record_callback([&](const int16_t* samples, int count) {
+        video_samples += count;
+        video_pair[0] = samples[0];
+        video_pair[1] = samples[1];
+    });
+    mixer.set_capture_callback([&](const int16_t* samples, int count) {
+        wav_samples += count;
+        wav_pair[0] = samples[0];
+        wav_pair[1] = samples[1];
+    });
+
+    dac.write_channel(0, 0xFF);
+    mixer.generate_sample(beeper, turbosound, dac);
+    check("WAV and video callbacks receive the same mixed sample",
+          video_samples == 1 && wav_samples == 1 &&
+          video_pair[0] == wav_pair[0] && video_pair[1] == wav_pair[1]);
+}
+
+void cold_boot_continuity_test()
+{
+    const auto path = temp_file("audio-cold-boot", ".wav");
+    AudioRecorder recorder;
+    check("cold-boot WAV starts", recorder.start(path.string()));
+
+    EmulatorConfig cfg;
+    cfg.load_file = "direct-load.nex";
+    int dac_writes = 0;
+    cfg.audio_capture_callback = [&recorder](const int16_t* samples, int count) {
+        recorder.capture(samples, count);
+    };
+    cfg.dac_write_callback = [&dac_writes](uint64_t, int, uint8_t) {
+        ++dac_writes;
+    };
+
+    Emulator emulator;
+    check("initial emulator init", emulator.init(cfg));
+    emulator.dac().write_channel(0, 0xFF);
+    emulator.mixer().generate_sample(emulator.beeper(), emulator.turbosound(),
+                                     emulator.dac());
+
+    emulator_cold_boot(emulator, cfg);
+    emulator.dac().write_channel(2, 0x00);
+    emulator.mixer().generate_sample(emulator.beeper(), emulator.turbosound(),
+                                     emulator.dac());
+
+    emulator.mixer().set_capture_callback({});
+    check("cold-boot WAV finalizes", recorder.stop());
+    const auto bytes = read_binary(path);
+    check("WAV spans a cold boot",
+          bytes.size() == 52 && bytes.size() >= 44 && u32_le(bytes, 40) == 8);
+    check("DAC callback reattaches after a cold boot", dac_writes == 2);
+    std::filesystem::remove(path);
+}
+
+void dac_trace_format_test()
+{
+    const auto path = temp_file("dac-trace", ".csv");
+    DacTraceRecorder recorder;
+    check("DAC trace starts and rejects a second start",
+          recorder.start(path.string()) && !recorder.start(path.string()));
+    recorder.capture(100, 0, 128);
+    recorder.capture(101, 3, 200);
+    recorder.capture(5, 1, 7);
+    check("DAC trace finalizes", recorder.stop());
+    check("DAC trace CSV and cold-boot segment", read_text(path) ==
+          "segment,tstate,channel,value\n"
+          "0,100,0,128\n"
+          "0,101,3,200\n"
+          "1,5,1,7\n");
+    std::filesystem::remove(path);
+}
+
+}  // namespace
+
+int main()
+{
+    wav_format_test();
+    dac_callback_mapping_test();
+    mixer_callback_fanout_test();
+    cold_boot_continuity_test();
+    dac_trace_format_test();
+
+    const int total = passed + failed;
+    std::printf("Total: %d Passed: %d Failed: %d Skipped: 0\n",
+                total, passed, failed);
+    return failed == 0 ? 0 : 1;
+}

--- a/test/refresh-subsystem-status.sh
+++ b/test/refresh-subsystem-status.sh
@@ -110,6 +110,7 @@ BEGIN {
     M["audio_nextreg_test"]            = "Audio (NextREG)"
     M["audio_port_dispatch_test"]      = "Audio (port dispatch)"
     M["audio_pacing_test"]             = "Audio (pacing)"
+    M["audio_capture_test"]            = "Audio (capture)"
     M["present_cadence_test"]          = "Present cadence"
     M["tick_stats_test"]               = "Tick-delivery stats"
     M["present_count_test"]            = "Present count (widget)"

--- a/test/unit-tests.conf
+++ b/test/unit-tests.conf
@@ -35,7 +35,7 @@
 #
 # A green triplet is only as trustworthy as its denominator.
 
-# expect: 55
+# expect: 56
 #   The number of suites declared below, pinned.
 #   Without it, the manifest-vs-CMake cross-check is a TAUTOLOGY against the one
 #   edit that matters most: delete a suite's add_test() from test/CMakeLists.txt AND
@@ -83,6 +83,7 @@ audio_test                        138
 audio_nextreg_test                 33
 audio_port_dispatch_test           23
 audio_pacing_test                  22
+audio_capture_test                 17
 present_cadence_test               34
 tick_stats_test                    32
 log_test                           10


### PR DESCRIPTION
## Summary

- add --wav-record FILE for direct 44.1 kHz, 16-bit stereo PCM capture without ffmpeg or an audio device
- keep WAV capture active across cold boots and sibling-NEX chaining
- add --dac-trace FILE for timestamped physical DAC writes in CSV format
- document both options and report invalid capture combinations clearly

## Tests

- CTest: 52/52 passed
- full regression suite: 96/96 passed
- functional coverage verifies WAV output across sibling-NEX chaining and DAC channel writes through the CLI

## Review checklist (maintainer-maintained — updated at each review)

**Common**
- [x] Tests included that exercise the change
- [x] No existing tests modified
- [x] Fixtures license-clean
- [x] Code quality / style consistent with the project
- [x] No new dependencies (python3 already used by regression.sh)

**Feature PR**
- [x] Functionality description with an explicit use case (PR description suffices)
- [x] Design document — waived by owner (diagnostic tool; PR description is enough)
- [x] Tests are discriminative: FAIL without the feature — demonstrated (0/2 vs v0.98.34; mechanism verified)

**Project landing gates**
- [x] test/unit-tests.conf entry (audio_capture_test 17; make unit-test green, 4997/4997 across 56 suites)
- [x] Unconditional test row count (17, always)
- [x] Rebase onto current origin/main (clean)

_Reviewed at commit dec09f95 on 2026-07-19: REJECT (4 blockers). Re-reviewed at commit baafe019 on 2026-07-19: **APPROVE** — all blockers fixed, full suite green in a clean verification build. dd314553 is a maintainer follow-up (exit-code precedence one-liner)._
