### PR TITLE
test: report literal screenshot pixel differences (GH #76)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -9,6 +9,7 @@
 - `--sdcard-readonly` opens the SD card read-only, so a run cannot alter a shared image
 
 ### Bug Fixes
+- Regression screenshot failures now report the actual differing-pixel count
 - Ports `$FF3B` (ULA+ Data) and `$243B` now return the driven value, not a fixed zero
 - ULA palette entries above the standard range no longer show invented colours
 - NEX files with LoRes, Hi-Res or Hi-Colour screens load both halves correctly

--- a/test/00regression/functional_tests.conf
+++ b/test/00regression/functional_tests.conf
@@ -16,7 +16,7 @@
 # The screenshot tests have their own manifest: regression_tests.conf.
 # The assertion lint is always row 1 and is not listed here.
 
-# expect: 35
+# expect: 36
 #   The number of functional tests declared below, pinned. regression.sh FAILS if the
 #   count here and the rows below ever disagree. Without it, deleting a test
 #   from this file just shrinks both sides of the completeness check together
@@ -26,6 +26,7 @@
 #   Change this number only when you deliberately add or remove a test.
 
 harness-selftest-func
+png-diff-func
 sdcard-provision-func
 magic-bp-func
 magic-port-func

--- a/test/00regression/scripts/png-diff-func.sh
+++ b/test/00regression/scripts/png-diff-func.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Pin png_diff() to a literal differing-pixel count. Sourced by regression.sh;
+# also directly executable.
+# shellcheck source=test/00regression/test-functions.inc
+set -euo pipefail
+source "$(dirname "${BASH_SOURCE[0]}")/../test-functions.inc"
+
+if want png-diff-func; then
+    begin_func png-diff-func
+    if ! $HAS_COMPARE; then
+        skip_row " (no ImageMagick)"
+    else
+        if command -v magick &>/dev/null; then
+            image_cmd=(magick)
+        elif command -v convert &>/dev/null; then
+            image_cmd=(convert)
+        else
+            fail_row " (compare exists, but no ImageMagick image command was found)"
+            image_cmd=()
+        fi
+
+        if [[ ${#image_cmd[@]} -gt 0 ]]; then
+            base="$TMP_DIR/png-diff-base.png"
+            one="$TMP_DIR/png-diff-one.png"
+            red="$TMP_DIR/png-diff-red.png"
+            two="$TMP_DIR/png-diff-two.png"
+            if ! "${image_cmd[@]}" -size 4x3 xc:black "$base" 2>/dev/null \
+                || ! "${image_cmd[@]}" "$base" -fill white \
+                    -draw 'point 1,1' "$one" 2>/dev/null \
+                || ! "${image_cmd[@]}" "$base" -fill red \
+                    -draw 'point 1,1' "$red" 2>/dev/null \
+                || ! "${image_cmd[@]}" "$base" -fill white \
+                    -draw 'point 1,1 point 2,1' "$two" 2>/dev/null; then
+                fail_row " (could not create synthetic image fixtures)"
+            else
+                same_count=$(png_diff "$base" "$base")
+                one_count=$(png_diff "$base" "$one")
+                red_count=$(png_diff "$base" "$red")
+                two_count=$(png_diff "$base" "$two")
+                missing_count=$(png_diff "$base" "$TMP_DIR/absent.png" 424242)
+                if [[ "$same_count" -eq 0 && "$one_count" -eq 1 \
+                      && "$red_count" -eq 1 && "$two_count" -eq 2 \
+                      && "$missing_count" -eq 424242 ]]; then
+                    pass_row " (0 identical; 1 single-channel/full-colour; 2 two-pixel; failure sentinel preserved)"
+                else
+                    fail_row " (same=$same_count one=$one_count red=$red_count two=$two_count missing=$missing_count)"
+                fi
+            fi
+        fi
+    fi
+fi
+
+[[ "${BASH_SOURCE[0]}" != "$0" ]] || standalone_summary

--- a/test/00regression/test-functions.inc
+++ b/test/00regression/test-functions.inc
@@ -108,12 +108,38 @@ standalone_summary() {
     [[ "$fail" -eq 0 ]] || exit 1
 }
 
-# png_diff <a> <b> [sentinel] — differing-pixel count from `compare -metric AE`;
-# a parse failure yields <sentinel> (default 999999, i.e. "treat as different").
+# png_diff <a> <b> [sentinel] — count pixels whose channels differ exactly.
+#
+# Do not use `compare -metric AE` here. ImageMagick 7.1.2 Q16-HDRI reports
+# a quantum-scaled absolute-error sum for that metric (one black -> white
+# pixel is 65535), not a pixel count. Build an any-channel binary difference
+# mask instead, then its mean times its area is the literal number of changed
+# pixels. A command or parse failure yields <sentinel> (default 999999, i.e.
+# "treat as different").
 png_diff() {
-    local raw
-    raw=$(compare -metric AE "$1" "$2" /dev/null 2>&1) || true
-    awk '{printf "%d", $1+0}' <<< "$raw" 2>/dev/null || echo "${3:-999999}"
+    local raw sentinel=${3:-999999}
+    local -a image_cmd
+    if command -v magick &>/dev/null; then
+        image_cmd=(magick)
+    elif command -v convert &>/dev/null; then
+        image_cmd=(convert)
+    else
+        echo "$sentinel"
+        return
+    fi
+
+    raw=$("${image_cmd[@]}" "$1" "$2" \
+        -compose difference -composite -threshold 0 \
+        -separate -evaluate-sequence max \
+        -format '%[fx:mean*w*h]' info: 2>/dev/null) || {
+        echo "$sentinel"
+        return
+    }
+    if [[ "$raw" =~ ^[0-9]+([.][0-9]+)?$ ]]; then
+        printf '%.0f\n' "$raw"
+    else
+        echo "$sentinel"
+    fi
 }
 
 # count_streams <file> <codec_type> — number of streams of that type in the


### PR DESCRIPTION
## Summary

Fixes #76.

`png_diff()` now builds a binary any-channel difference mask and reports its literal changed-pixel count. This preserves the existing zero/non-zero pass contract while making failure diagnostics meaningful across ImageMagick versions.

A known-answer functional test covers identical images, one full-colour changed pixel, one single-channel changed pixel, two changed pixels, and the existing failure sentinel.

## Discriminative evidence

On Fedora 44 with ImageMagick 7.1.2 Q16-HDRI, the previous `compare -metric AE` implementation reports `65535` for a synthetic one-pixel difference. The fixed implementation and new functional test report `1`.

The final commit passes:

- clean `make gui-release`
- `make unit-test`: 5,492 passed, 0 failed, 3 expected skips across 5,495 assertions
- direct FUSE corpus: 1,356/1,356 passed
- `JNEXT_TEST_JOBS=4 bash test/00regression/regression.sh`: 101/101 passed

## Review checklist (maintainer-maintained — updated at each review; supersedes the earlier contributor-authored checklist)

**Common**
- [x] Tests included that exercise the change (png-diff-func known-answer self-test; function- and row-level discriminative proof reproduced by the reviewer)
- [x] No existing tests modified — **owner-approved (jorgegv, 2026-07-24)**: the `png_diff()` shared-machinery rewrite is accepted. Evidence basis: all 8 consumers enumerated green standalone AND integrated; ground-truth 12345-pixel cross-check exact; the rewrite also fixes a latent false-pass where comparator crashes parsed as 0="identical".
- [x] Fixtures license-clean (synthetic PNGs generated at runtime)
- [x] Code quality / style consistent with the project
- [x] No new dependencies (`magick`/`convert` ship with the already-required ImageMagick; note the pre-existing `HAS_COMPARE` probe now checks the wrong binary — see findings)

**Bugfix PR**
- [x] Bug description via linked issue #76
- [x] Tests are discriminative — reproduced by the reviewer: reverting `png_diff()` to the AE implementation fails the known-answer test exactly as #76 describes (`one=65535`, sentinel lost); a doctored 25-pixel reference fails a real row with exactly "25 pixels differ"

**Blockers** (all resolved maintainer-side, 2026-07-24)
1. ~~ChangeLog~~ hunk dropped by maintainer fixup: the new line is inserted under the already-published `## v0.99.0` section — move it under `## Unreleased` or (preferred) drop the hunk; the maintainer updates the ChangeLog at release time.
2. ~~Owner sign-off on the shared-machinery change~~ — **granted 2026-07-24** (see the ticked box above).

**Minors (non-blocking, please fix with the blocker)**
- `test/00regression/scripts/sdcard-readonly-func.sh:80-82`: stale comment still describes the pre-fix "scaled error sum" semantics.
- Commit message claims IM6+IM7 validation; only IM7 was reproducible here — treat IM6 as untested.

_Reviewed at commit `f9930974` on `2026-07-24`. Verdict: REJECT (pending the two blockers)._

_Re-reviewed at commit `22155371` (maintainer-rebased landing branch) on `2026-07-24`. Verdict: **APPROVE** — merged._