### PR TITLE
fix: fail when video recording does not materialize (GH #78)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -9,6 +9,7 @@
 - `--sdcard-readonly` opens the SD card read-only, so a run cannot alter a shared image
 
 ### Bug Fixes
+- `--record` now exits non-zero when FFmpeg fails or produces an empty MP4
 - Ports `$FF3B` (ULA+ Data) and `$243B` now return the driven value, not a fixed zero
 - ULA palette entries above the standard range no longer show invented colours
 - NEX files with LoRes, Hi-Res or Hi-Colour screens load both halves correctly

--- a/src/core/video_recorder.cpp
+++ b/src/core/video_recorder.cpp
@@ -226,6 +226,20 @@ bool VideoRecorder::stop()
             "no output) — encoding video-only");
     }
 
+    // FFmpeg is invoked with -y, so this request explicitly replaces its
+    // target. Remove it ourselves first: otherwise a broken/no-op encoder
+    // could exit 0 and leave a stale non-empty MP4 that looks like this run's
+    // result to the validation below.
+    std::error_code output_ec;
+    fs::remove(output_path_, output_ec);
+    if (output_ec) {
+        std::remove(video_tmp_.c_str());
+        std::remove(audio_tmp_.c_str());
+        Log::emulator()->error("VideoRecorder: cannot replace output file {}: {}",
+                               output_path_, output_ec.message());
+        return false;
+    }
+
     Log::emulator()->debug("VideoRecorder: encoding with FFmpeg...");
     int ret = -1;
     for (const auto& enc : encoders) {
@@ -256,6 +270,14 @@ bool VideoRecorder::stop()
 
     if (ret != 0) {
         Log::emulator()->error("VideoRecorder: FFmpeg encoding failed (exit code {})", ret);
+        return false;
+    }
+
+    const auto output_size = fs::file_size(output_path_, output_ec);
+    if (output_ec || output_size == 0) {
+        Log::emulator()->error(
+            "VideoRecorder: FFmpeg reported success but produced no usable output at {}",
+            output_path_);
         return false;
     }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -778,10 +778,15 @@ int main(int argc, char* argv[]) {
             }
         }
 
+        // Capture requests are part of the CLI contract: if one cannot start
+        // or finalize, an otherwise-clean run must not report success.
+        bool capture_ok = true;
+
         // Start video recording if requested (after init, before run).
         if (!record_file.empty()) {
             if (!app.emulator().start_recording(record_file)) {
                 Log::emulator()->error("Failed to start recording to {}", record_file);
+                capture_ok = false;
             }
         }
 
@@ -800,14 +805,14 @@ int main(int argc, char* argv[]) {
 
         // Stop recording before shutdown (encodes the MP4).
         if (app.emulator().video_recorder().is_recording()) {
-            app.emulator().stop_recording();
+            capture_ok = app.emulator().stop_recording() && capture_ok;
         }
 
-        bool capture_ok = true;
         if (audio_recorder.is_recording()) {
             app.emulator().mixer().set_capture_callback({});
-            capture_ok = audio_recorder.stop();
-            if (!capture_ok) {
+            const bool audio_ok = audio_recorder.stop();
+            capture_ok = audio_ok && capture_ok;
+            if (!audio_ok) {
                 Log::audio()->error("Failed to finalize WAV recording: {}",
                                     audio_recorder.last_error());
             }

--- a/test/00regression/functional_tests.conf
+++ b/test/00regression/functional_tests.conf
@@ -16,7 +16,7 @@
 # The screenshot tests have their own manifest: regression_tests.conf.
 # The assertion lint is always row 1 and is not listed here.
 
-# expect: 35
+# expect: 36
 #   The number of functional tests declared below, pinned. regression.sh FAILS if the
 #   count here and the rows below ever disagree. Without it, deleting a test
 #   from this file just shrinks both sides of the completeness check together
@@ -30,6 +30,7 @@ sdcard-provision-func
 magic-bp-func
 magic-port-func
 video-record-func
+video-record-status-func
 wav-record-func
 dac-trace-func
 render-skip-turbo-func

--- a/test/00regression/scripts/video-record-status-func.sh
+++ b/test/00regression/scripts/video-record-status-func.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# Pin --record's process-status contract (GH #78). Sourced by regression.sh;
+# also directly executable.
+# shellcheck source=test/00regression/test-functions.inc
+set -euo pipefail
+source "$(dirname "${BASH_SOURCE[0]}")/../test-functions.inc"
+
+if want video-record-status-func; then
+    begin_func video-record-status-func
+    success_file="$TMP_DIR/jnext_test_status_success.mp4"
+    start_file="$TMP_DIR/jnext_test_start_failed.mp4"
+    failed_file="$TMP_DIR/jnext_test_failed_recording.mp4"
+    empty_file="$TMP_DIR/jnext_test_empty_recording.mp4"
+    fake_bin="$TMP_DIR/fake-ffmpeg-bin"
+    mkdir -p "$fake_bin"
+    {
+        echo '#!/bin/sh'
+        echo '[ "$JNEXT_TEST_FFMPEG_MODE" = "probe-fail" ] && exit 41'
+        echo '[ "$1" = "-version" ] && exit 0'
+        echo 'for output_path do :; done'
+        echo '[ "$JNEXT_TEST_FFMPEG_MODE" = "empty-success" ] && exit 0'
+        echo ': > "$output_path"'
+        echo 'exit 42'
+    } > "$fake_bin/ffmpeg"
+    chmod +x "$fake_bin/ffmpeg"
+
+    # A successful recording must remain successful. The older recording row
+    # validates its streams but deliberately swallows the process status; this
+    # row pins the missing half of that contract explicitly.
+    if timeout --foreground --kill-after=5s 20s "$JNEXT" --headless \
+        "${SD_CARD_ARGS[@]}" --record "$success_file" \
+        --delayed-automatic-exit-frames 5 &>/dev/null; then
+        success_rc=0
+    else
+        success_rc=$?
+    fi
+
+    # The success-without-output stub does not touch its target. Seed a stale
+    # non-empty file so the recorder must remove it before encoding; merely
+    # checking "a non-empty file exists afterwards" would accept the stale one.
+    printf 'stale recording\n' > "$empty_file"
+    if start_out=$(PATH="$fake_bin:/usr/bin:/bin" JNEXT_TEST_FFMPEG_MODE=probe-fail \
+        timeout --foreground --kill-after=5s 20s "$JNEXT" --headless \
+        "${SD_CARD_ARGS[@]}" --record "$start_file" \
+        --delayed-automatic-exit-frames 5 2>&1); then
+        start_rc=0
+    else
+        start_rc=$?
+    fi
+    if failed_out=$(PATH="$fake_bin:/usr/bin:/bin" JNEXT_TEST_FFMPEG_MODE=fail \
+        timeout --foreground --kill-after=5s 20s "$JNEXT" --headless \
+        "${SD_CARD_ARGS[@]}" --record "$failed_file" \
+        --delayed-automatic-exit-frames 5 2>&1); then
+        failed_rc=0
+    else
+        failed_rc=$?
+    fi
+    if empty_out=$(PATH="$fake_bin:/usr/bin:/bin" JNEXT_TEST_FFMPEG_MODE=empty-success \
+        timeout --foreground --kill-after=5s 20s "$JNEXT" --headless \
+        "${SD_CARD_ARGS[@]}" --record "$empty_file" \
+        --delayed-automatic-exit-frames 5 2>&1); then
+        empty_rc=0
+    else
+        empty_rc=$?
+    fi
+
+    if [[ "$success_rc" -eq 0 && -s "$success_file" \
+          && "$start_rc" -ne 0 && ! -e "$start_file" \
+          && "$failed_rc" -ne 0 && ! -s "$failed_file" \
+          && "$empty_rc" -ne 0 && ! -s "$empty_file" ]] \
+        && grep -qF "Failed to start recording" <<< "$start_out" \
+        && grep -qF "FFmpeg encoding failed" <<< "$failed_out" \
+        && grep -qF "reported success but produced no usable output" <<< "$empty_out"; then
+        pass_row " (success exits 0; start, encode and empty-output failures exit non-zero)"
+    else
+        fail_row " (success_rc=$success_rc success_size=$([[ -s "$success_file" ]] && echo nonzero || echo zero) start_rc=$start_rc fail_rc=$failed_rc empty_rc=$empty_rc)"
+    fi
+fi
+
+[[ "${BASH_SOURCE[0]}" != "$0" ]] || standalone_summary


### PR DESCRIPTION
## Summary

Fixes #78.

Headless `--record` now exits non-zero when FFmpeg cannot start, encoding fails, or FFmpeg exits successfully without producing a non-empty output file. The recorder removes a stale target before encoding so an old file cannot be mistaken for a successful new capture.

The existing video regression remains byte-for-byte unchanged. A separate status-focused functional test verifies the successful and failed process-exit contracts.

## Discriminative evidence

Against the pre-fix JNEXT binary, the new test fails with:

`success_rc=0 success_size=nonzero start_rc=0 fail_rc=0 empty_rc=0`

Against this commit, it passes with a real non-empty MP4 and reports:

`success exits 0; start, encode and empty-output failures exit non-zero`

The final commit passes:

- clean `make gui-release`
- `make unit-test`: 5,492 passed, 0 failed, 3 expected skips across 5,495 assertions
- direct FUSE corpus: 1,356/1,356 passed
- `JNEXT_TEST_JOBS=4 bash test/00regression/regression.sh`: 101/101 passed

## Review checklist (maintainer-maintained — updated at each review; supersedes the earlier contributor-authored checklist)

**Common**
- [x] Tests included that exercise the change (video-record-status-func, 4 legs)
- [x] No existing tests modified (functional_tests.conf pin 35->36 + one new row; video-record-func.sh byte-identical)
- [x] Fixtures license-clean (plain sh stubs, runtime-generated files)
- [x] Code quality / style consistent with the project
- [x] No new dependencies (ffmpeg already optional + runtime-only)

**Bugfix PR**
- [x] Linked bug issue (#78)
- [x] Tests are discriminative — reproduced by the reviewer: pre-fix binary fails all three failure legs (rc=0 everywhere), fixed binary passes; success leg produces a real, probed MP4

**Required before merge** (all completed maintainer-side, 2026-07-24)
1. ChangeLog: on a plain merge your line lands inside the already-released `## v0.99.0` section (the branch forked before main grew its `## Unreleased` header). Simplest: drop the hunk — the maintainer updates the ChangeLog at release time.
2. The new stale-target-removal-failure branch (src/core/video_recorder.cpp:233-240) is untested. Deterministic repro without permission tricks: point `--record` at a non-empty directory (`fs::remove` fails ENOTEMPTY). Please add it as a 5th leg of video-record-status-func.
3. One sentence in doc/man/jnext.1.md (EXIT STATUS + the recording narrative) stating the new `--record` failure -> non-zero-exit contract, mirroring the existing `--delayed-screenshot` wording; regenerate the committed outputs (`make docs-man`).

_Reviewed at commit `7ea2a782` on `2026-07-24`. Verdict: REJECT (pending the three items above)._

_Re-reviewed at commit `3ea7eefa` (maintainer-rebased landing branch) on `2026-07-24`. Verdict: **APPROVE** — merged as part of v0.99.13. All three items completed maintainer-side; leg-5 mutation-verified discriminative._